### PR TITLE
スタンダード第31回課題

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -6,18 +6,22 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import raisetech.StudentManagement.data.StudentCourseStatus;
 import raisetech.StudentManagement.domain.StudentDetail;
-import raisetech.StudentManagement.exception.TestException;
 import raisetech.StudentManagement.service.StudentService;
 
 /**
@@ -61,6 +65,31 @@ public class StudentController {
   }
 
   /**
+   * 受講生詳細の条件検索機能 名前、カナ名、メールアドレス、住所、年齢、性別を選択して検索します
+   *
+   * @param name        名前
+   * @param kanaName    カナ名
+   * @param mailAddress メールアドレス
+   * @param area        住所
+   * @param age         年齢
+   * @param gender      性別
+   * @return 受講生詳細
+   */
+  @GetMapping("/filteredStudentList")
+  public ResponseEntity<Object> filteredStudentList(@RequestParam(required = false) String name,
+      @RequestParam(required = false) String kanaName,
+      @RequestParam(required = false) String mailAddress,
+      @RequestParam(required = false) String area,
+      @RequestParam(required = false) Integer age,
+      @RequestParam(required = false) String gender) {
+    List<StudentDetail> filteredStudentList = service.searchFilteredStudentList(name, kanaName, mailAddress, area, age, gender);
+    if (filteredStudentList.isEmpty()) {
+      return ResponseEntity.ok(Collections.emptyList());  // ここで 200 OK と空リストを返す
+    }
+    return ResponseEntity.ok(filteredStudentList);
+  }
+
+  /**
    * 受講生詳細の新規登録機能
    *
    * @param studentDetail 受講生詳細
@@ -71,8 +100,7 @@ public class StudentController {
   @PostMapping("/registerStudent")
   public ResponseEntity<StudentDetail> registerStudent(
       @RequestBody @Valid StudentDetail studentDetail) {
-    StudentDetail responseStudentDetail1 = service.registerStudent(studentDetail);
-    return ResponseEntity.ok(responseStudentDetail1);
+    return ResponseEntity.ok(service.registerStudent(studentDetail));
   }
 
   /**
@@ -89,10 +117,62 @@ public class StudentController {
     return ResponseEntity.ok("更新処理が成功しました。");
   }
 
-  @Operation(summary = "例外処理", description = "例外処理を行った後、エラーメッセージを返します。")
-  @GetMapping("/studentListException")
-  public List<StudentDetail> getStudentListException() throws TestException {
-    throw new TestException("エラーが発生しました。");
+  /**
+   * 受講生コースの申込状況の更新機能
+   * 受講生コースの申込状況
+   *
+   * @param status 受講コースのステータス
+   * @return message
+   */
+  @PutMapping("/updateCourseStatus")
+  public ResponseEntity<String> updateCourseStatus(@RequestBody @Valid StudentCourseStatus status) {
+    service.updateStudentCourseStatus(status);
+    return ResponseEntity.ok("受講生コース申込状況の更新に成功しました。");
+  }
+
+  /**
+   * 受講生コースの申込状況の全件検索を行います
+   *
+   * @return コースの申込状況（全件）
+   */
+  @GetMapping("/courseStatuses")
+  public List<StudentCourseStatus> getAllCourseStatuses() {
+    return service.getAllCourseStatuses();
+  }
+
+  /**
+   * 受講生コースの申込状況について
+   *
+   * @param courseName 受講コース名
+   * @return コースの申込状況（任意のコース名）
+   */
+  @GetMapping("/searchCourseStatuses")
+  public List<StudentCourseStatus> searchCourseStatuses(@RequestParam String courseName) {
+    return service.getCourseStatusesByCourseName(courseName);
+  }
+
+  /**
+   * 受講生情報の論理削除を行います
+   *
+   * @param id 受講生ID
+   * @return message
+   */
+  @DeleteMapping("/students/{id}")
+  public ResponseEntity<String> deleteStudent(@PathVariable String id) {
+    service.deleteStudent(id);
+    return ResponseEntity.ok("受講生情報を削除しました。");
+  }
+
+  /**
+   * 受講生コース情報の論理削除を行います
+   *
+   * @param id 受講生コースID
+   * @return message
+   */
+  @DeleteMapping("/students/courses/{id}")
+  public ResponseEntity<String> deleteStudentCourse(@PathVariable String id) {
+    service.deleteStudentCourse(id);
+    return ResponseEntity.ok("受講生コース情報を削除しました。");
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -37,5 +37,6 @@ public class Student {
   private String gender;
 
   private String remark;
+
   private boolean isDeleted;
 }

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -3,6 +3,7 @@ package raisetech.StudentManagement.data;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,4 +22,6 @@ public class StudentCourse {
 
   private LocalDateTime startingDate;
   private LocalDateTime endDate;
+
+  private List<StudentCourseStatus> studentCourseStatusList;
 }

--- a/src/main/java/raisetech/StudentManagement/data/StudentCourseStatus.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourseStatus.java
@@ -1,0 +1,16 @@
+package raisetech.StudentManagement.data;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Schema(description = "受講生コースの申込状況")
+@Getter
+@Setter
+public class StudentCourseStatus {
+
+  private String id;
+  private String courseName;
+  private String courseStatusId;
+  private String status;
+}

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.data.StudentCourseStatus;
 
 /**
  * 受講生テーブルと受講生コース情報テーブルに紐づくRepository
@@ -35,6 +36,21 @@ public interface StudentRepository {
   List<StudentCourse> searchStudentsCourseList();
 
   /**
+   * 受講生の条件検索を行います
+   * 名前、カナ名、メールアドレス、住所、年齢、性別
+   *
+   * @param name　名前
+   * @param kanaName　カナ名
+   * @param mailAddress　メールアドレス
+   * @param area　住所
+   * @param age　年齢
+   * @param gender　性別
+   * @return 該当する受講生詳細
+   */
+  List<Student> searchFilteredStudent(String name, String kanaName,
+      String mailAddress, String area, Integer age, String gender);
+
+  /**
    * 受講生IDに紐づく受講生コース情報を検索します
    *
    * @param studentId 受講生ID
@@ -59,6 +75,14 @@ public interface StudentRepository {
   void registerStudentCourse(StudentCourse studentCourse);
 
   /**
+   * 受講生コースの申込状況の新規登録を行います
+   *
+   * @param studentCourseStatus コースの申込状況
+   */
+  @Options(useGeneratedKeys = true, keyProperty = "id")
+  void registerStudentCourseStatus(StudentCourseStatus studentCourseStatus);
+
+  /**
    * 受講生を更新します
    *
    * @param student 受講生
@@ -71,4 +95,42 @@ public interface StudentRepository {
    * @param studentCourse 受講生コース情報
    */
   void updateStudentCourse(StudentCourse studentCourse);
+
+
+  /**
+   * 受講生コースの申込状況の全件検索を行います
+   *
+   * @return 受講生コースの申込状況（全件）
+   */
+  List<StudentCourseStatus> searchAllCourseStatuses();
+
+  /**
+   * 受講生コースの申込状況の条件検索を行います。任意のコース名の申込状況を表示します
+   *
+   * @param courseName コース名
+   * @return 受講生コースの申込状況（任意のコース名）
+   */
+  List<StudentCourseStatus> searchCourseStatusesByCourseName(String courseName);
+
+  /**
+   * 受講生コースの申込状況の更新を行います。
+   *
+   * @param status 受講生コースの申込状況のステータス
+   */
+  void updateStudentCourseStatus(StudentCourseStatus status);
+
+  /**
+   * 受講生情報の削除を行います。特定のIDの受講生情報を削除します
+   *
+   * @param id 受講生ID
+   * @return
+   */
+  void deleteStudentById(String id);
+
+  /**
+   * 受講生コース情報の削除を行います。特定のコース情報の受講生コース情報を削除します
+   *
+   * @param id 受講生コースID
+   */
+  void deleteStudentCourseById(String id);
 }

--- a/src/main/resources/mapper/studentRepository.xml
+++ b/src/main/resources/mapper/studentRepository.xml
@@ -7,6 +7,7 @@
   <select id="search" resultType="raisetech.StudentManagement.data.Student">
     SELECT *
     FROM students
+    WHERE isDeleted = FALSE;
   </select>
 
   <!-- 受講生の単一検索 -->
@@ -14,12 +15,47 @@
     SELECT *
     FROM students
     WHERE id = #{id}
+    AND isDeleted = FALSE;
+  </select>
+
+  <!-- 受講生の条件検索　
+  名前、カナ名、メールアドレス、住所、年齢、性別-->
+  <select id="searchFilteredStudent" resultType="raisetech.StudentManagement.data.Student">
+    SELECT *
+    FROM students
+    WHERE isDeleted = FALSE
+
+    <if test="name != null and name != ''">
+    AND name LIKE CONCAT ('%', #{name}, '%')
+    </if>
+
+    <if test="kanaName != null and kanaName != ''">
+      AND kana_name LIKE CONCAT ('%', #{kanaName}, '%')
+    </if>
+
+    <if test="mailAddress != null and mailAddress != ''">
+      AND mail_address LIKE CONCAT ('%', #{mailAddress}, '%')
+    </if>
+
+    <if test="area != null and area != ''">
+      AND area LIKE CONCAT ('%', #{area}, '%')
+    </if>
+
+    <if test="age != null">
+      AND age = #{age}
+    </if>
+
+    <if test="gender != null and gender != ''">
+      AND gender LIKE CONCAT ('%', #{gender}, '%')
+    </if>
+
   </select>
 
   <!-- 受講生のコース情報の全件検索 -->
   <select id="searchStudentsCourseList" resultType="raisetech.StudentManagement.data.StudentCourse">
     SELECT *
     FROM students_courses
+    WHERE isDeleted = FALSE
   </select>
 
   <!-- 受講生のコース情報の単一検索 -->
@@ -27,6 +63,7 @@
     SELECT *
     FROM students_courses
     WHERE student_id = #{studentId}
+    AND isDeleted = FALSE
   </select>
 
   <!-- 受講生の新規登録 -->
@@ -40,9 +77,17 @@
   <!-- 受講生コース情報の新規登録 -->
   <insert id="registerStudentCourse" keyProperty="id" useGeneratedKeys="true">
     INSERT INTO students_courses
-    (student_id, course_name, starting_date, end_date)
+    (student_id, course_name, starting_date, end_date, isDeleted)
     VALUES
-    (#{studentId}, #{courseName}, #{startingDate}, #{endDate})
+    (#{studentId}, #{courseName}, #{startingDate}, #{endDate}, false)
+  </insert>
+
+  <!-- 受講生コースの申込状況の登録 -->
+  <insert id="registerStudentCourseStatus" keyProperty="id" useGeneratedKeys="true">
+    INSERT INTO student_course_status
+    (course_name, course_status_id, status)
+    VALUES
+    (#{courseName}, #{courseStatusId}, #{status})
   </insert>
 
   <!-- 受講生の更新 -->
@@ -64,6 +109,41 @@
   <update id="updateStudentCourse">
     UPDATE students_courses SET
     course_name = #{courseName}
+    WHERE id = #{id}
+    AND isDeleted = FALSE
+  </update>
+
+  <!-- 受講生コース申込状況の全件検索機能 -->
+  <select id="searchAllCourseStatuses">
+    SELECT *
+    FROM student_course_status
+  </select>
+
+  <!-- 受講生コース申込状況の条件検索 -->
+  <select id="searchCourseStatusesByCourseName">
+    SELECT *
+    FROM student_course_status
+    WHERE course_name = #{courseName}
+  </select>
+  
+  <!-- 受講生コース申込状況の更新 -->
+  <update id="updateStudentCourseStatus">
+    UPDATE student_course_status SET
+    status = #{status}
+    WHERE id = #{id}
+  </update>
+
+  <!-- 受講生情報の削除 -->
+  <update id="deleteStudentById">
+    UPDATE students SET
+    isDeleted = TRUE
+    WHERE id = #{id}
+  </update>
+
+  <!-- 受講生コース情報の削除 -->
+  <update id="deleteStudentCourseById">
+    UPDATE students_courses SET
+    isDeleted = TRUE
     WHERE id = #{id}
   </update>
 

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -1,17 +1,24 @@
 package raisetech.StudentManagement.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.data.StudentCourseStatus;
 
 @MybatisTest
 class StudentRepositoryTest {
+
+  @Mock
+  private SqlSessionTemplate sqlSession;
 
   @Autowired
   private StudentRepository sut;
@@ -36,11 +43,20 @@ class StudentRepositoryTest {
   }
 
   @Test
+  void 受講生の条件検索が行えること() {
+    Student student = createStudent();
+    List<Student> actual = sut.searchFilteredStudent(
+        student.getName(), student.getKanaName(), student.getMailAddress(), student.getArea(), student.getAge(), student.getGender());
+    assertThat(actual.size()).isEqualTo(1);
+  }
+
+  @Test
   void 受講生コース情報の単一検索が行えること(){
     String id = "1";
     List<StudentCourse> actual = sut.searchStudentCourseList(id);
     assertThat(actual.size()).isEqualTo(2);
   }
+
 
   @Test
   void 受講生の新規登録が行えること(){
@@ -48,9 +64,9 @@ class StudentRepositoryTest {
 
     sut.registerStudent(student);
 
-    List<Student> actual = sut.search();
+    List<Student> mockStudent = sut.search();
 
-    assertThat(actual.size()).isEqualTo(6);
+    assertThat(mockStudent.size()).isEqualTo(6);
   }
 
   @Test
@@ -64,6 +80,20 @@ class StudentRepositoryTest {
     sut.registerStudentCourse(studentCourse);
 
     List<StudentCourse> actual = sut.searchStudentsCourseList();
+
+    assertThat(actual.size()).isEqualTo(8);
+  }
+
+  @Test
+  void 受講生コースの申込状況の新規登録() {
+    StudentCourseStatus status = new StudentCourseStatus();
+    status.setCourseName("Java");
+    status.setCourseStatusId("99");
+    status.setStatus("仮登録");
+
+    sut.registerStudentCourseStatus(status);
+
+    List<StudentCourseStatus> actual = sut.searchAllCourseStatuses();
 
     assertThat(actual.size()).isEqualTo(8);
   }
@@ -90,6 +120,43 @@ class StudentRepositoryTest {
     StudentCourse updatedStudentCourse = sut.searchStudentCourseList("1").get(0);
     assertThat(updatedStudentCourse.getCourseName()).isEqualTo("Music");
   }
+
+  @Test
+  void 受講生コースの申込状況の全件検索() {
+    List<StudentCourseStatus> actual = sut.searchAllCourseStatuses();
+    assertThat(actual.size()).isEqualTo(7);
+  }
+
+  @Test
+  void 受講生コースの申込状況について特定のコースを受講している受講生の状況が検索できること() {
+    String courseName = "Java";
+
+    List<StudentCourseStatus> actual = sut.searchCourseStatusesByCourseName(courseName);
+
+    assertThat(actual.size()).isEqualTo(2);
+  }
+
+  @Test
+  void 受講生情報の論理削除() {
+    String id = "1";
+
+    sut.deleteStudentById(id);
+
+    List<Student> actual = sut.search();
+    assertThat(actual.size()).isEqualTo(4);
+  }
+
+  @Test
+  void 受講生コース情報の論理削除() {
+    String id = "1";
+
+    sut.deleteStudentCourseById(id);
+
+    List<StudentCourse> actual = sut.searchStudentsCourseList();
+    assertThat(actual.size()).isEqualTo(6);
+  }
+
+
 
   private Student createStudent() {
     Student student = new Student();

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -1,11 +1,13 @@
 package raisetech.StudentManagement.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.data.StudentCourseStatus;
 import raisetech.StudentManagement.domain.StudentDetail;
 import raisetech.StudentManagement.repository.StudentRepository;
 
@@ -69,6 +72,48 @@ class StudentServiceTest {
   }
 
   @Test
+  void 受講生詳細の条件検索() {
+    String name = "山田太郎";
+    String kanaName = "ヤマダタロウ";
+    String nickname = "タロ";
+    String mailAddress = "taro@example.com";
+    String area = "東京";
+    int age = 27;
+    String gender = "男性";
+
+    Student student = new Student();
+    List<Student> studentList = List.of(student);
+    student.setName(name);
+    student.setKanaName(kanaName);
+    student.setNickname(nickname);
+    student.setMailAddress(mailAddress);
+    student.setArea(area);
+    student.setAge(age);
+    student.setGender(gender);
+
+    List<StudentCourse> studentCourseList = new ArrayList<>();
+    List<StudentCourseStatus> studentCourseStatusList = new ArrayList<>();
+
+    when(repository.searchFilteredStudent(name, kanaName,mailAddress, area, age, gender))
+        .thenReturn(studentList);
+    when(repository.searchStudentsCourseList())
+        .thenReturn(studentCourseList);
+    when(repository.searchAllCourseStatuses())
+        .thenReturn(studentCourseStatusList);
+
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+    List<StudentDetail> expected = List.of(studentDetail);
+
+    List<StudentDetail> actual = sut.searchFilteredStudentList(name, kanaName,mailAddress, area, age, gender);
+
+    verify(repository, times(1)).searchFilteredStudent(name, kanaName, mailAddress, area, age, gender);
+    verify(repository, times(1)).searchStudentsCourseList();
+    verify(repository, times(1)).searchAllCourseStatuses();
+
+    assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
   void 受講生詳細の新規登録_リポジトリの処理が適切に呼び出せていること(){
     Student student = new Student();
     StudentCourse studentCourse = new StudentCourse();
@@ -78,24 +123,8 @@ class StudentServiceTest {
     sut.registerStudent(studentDetail);
 
     verify(repository, times(1)).registerStudent(student);
-    verify(repository, times(1)).registerStudentCourse(studentCourse);
-  }
-
-  @Test
-  void 受講生詳細の登録_初期化処理が行われること(){
-    String studentId = "99";
-    Student student = new Student();
-    student.setId(studentId);
-    StudentCourse studentCourse = new StudentCourse();
-
-    sut.initStudentsCourse(studentCourse, student.getId());
-
-    assertThat(studentId)
-        .isEqualTo(studentCourse.getStudentId());
-    assertThat(LocalDateTime.now().getHour())
-        .isEqualTo(studentCourse.getStartingDate().getHour());
-    assertThat(LocalDateTime.now().plusYears(1).getYear())
-        .isEqualTo(studentCourse.getEndDate().getYear());
+    verify(repository, times(1)).registerStudentCourse(any());
+    verify(repository, times(1)).registerStudentCourseStatus(any());
   }
 
   @Test
@@ -109,6 +138,63 @@ class StudentServiceTest {
 
     verify(repository, times(1)).updateStudent(student);
     verify(repository, times(1)).updateStudentCourse(studentCourse);
+  }
+
+  @Test
+  void 受講生コースの申込状況の更新() {
+    StudentCourseStatus status = new StudentCourseStatus();
+    status.setId("1");
+    status.setCourseStatusId("1");
+    status.setStatus("本申込");
+
+    sut.updateStudentCourseStatus(status);
+
+    verify(repository, times(1)).updateStudentCourseStatus(status);
+  }
+
+  @Test
+  void 受講生コースの申込状況の全件検索() {
+    List<StudentCourseStatus> statuses = List.of(new StudentCourseStatus());
+
+    when(repository.searchAllCourseStatuses()).thenReturn(statuses);
+
+    List<StudentCourseStatus> result = sut.getAllCourseStatuses();
+
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    verify(repository, times(1)).searchAllCourseStatuses();
+  }
+
+  @Test
+  void 受講生コースの申込状況の条件検索() {
+    String courseName = "Java";
+    List<StudentCourseStatus> statuses = List.of(new StudentCourseStatus());
+
+    when(repository.searchCourseStatusesByCourseName(courseName)).thenReturn(statuses);
+
+    List<StudentCourseStatus> result = sut.getCourseStatusesByCourseName(courseName);
+
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    verify(repository, times(1)).searchCourseStatusesByCourseName(courseName);
+  }
+
+  @Test
+  void 受講生情報の論理削除() {
+    String id = "99";
+
+    sut.deleteStudent(id);
+
+    verify(repository, times(1)).deleteStudentById(id);
+  }
+
+  @Test
+  void 受講生コース情報の論理削除() {
+    String id = "99";
+
+    sut.deleteStudentCourse(id);
+
+    verify(repository, times(1)).deleteStudentCourseById(id);
   }
 
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,16 +1,24 @@
-INSERT INTO students (name, kana_name, nickname, mail_address, area, age, gender)
-VALUES('山田太郎', 'ヤマダタロウ', 'タロ', 'taro@example.com', '東京', 27, '男性'),
-      ('鈴木一郎', 'スズキイチロウ', 'イチ', 'ichiro@example.com', '大阪', 30, '男性'),
-      ('田中花子', 'タナカハナコ', 'ハナ', 'hana@example.com', '北海道', 22, '女性'),
-      ('佐藤良子', 'サトウリョウコ', 'リョウ', 'ryoko@example.com', '福岡', 28, '女性'),
-      ('伊藤悠', 'イトウハルカ', 'ハル', 'haruka@example.com', '愛知', 35, 'その他');
+INSERT INTO students (name, kana_name, nickname, mail_address, area, age, gender, isDeleted)
+VALUES('山田太郎', 'ヤマダタロウ', 'タロ', 'taro@example.com', '東京', 27, '男性', false),
+      ('鈴木一郎', 'スズキイチロウ', 'イチ', 'ichiro@example.com', '大阪', 30, '男性', false),
+      ('田中花子', 'タナカハナコ', 'ハナ', 'hana@example.com', '北海道', 22, '女性', false),
+      ('佐藤良子', 'サトウリョウコ', 'リョウ', 'ryoko@example.com', '福岡', 28, '女性', false),
+      ('伊藤悠', 'イトウハルカ', 'ハル', 'haruka@example.com', '愛知', 35, 'その他', false);
 
-INSERT INTO students_courses (student_id, course_name, starting_date, end_date)
-VALUES(1, 'Music', '2024-04-01 00:00:00', '2025-03-31 00:00:00'),
-      (1, 'Design', '2024-06-01 00:00:00', '2024-11-30 00:00:00'),
-      (2, 'Java', '2024-05-01 00:00:00', '2025-03-31 00:00:00'),
-      (3, 'English', '2024-08-01 00:00:00', '2025-07-31 00:00:00'),
-      (4, 'Java', '2025-01-01 00:00:00', '2025-03-31 00:00:00'),
-      (4, 'Music', '2023-04-01 00:00:00', '2026-03-31 00:00:00'),
-      (5, 'Marketing', '2024-04-01 00:00:00', '2026-03-31 00:00:00');
+INSERT INTO students_courses (student_id, course_name, starting_date, end_date, isDeleted)
+VALUES(1, 'Music', '2024-04-01 00:00:00', '2025-03-31 00:00:00', false),
+      (1, 'Design', '2024-06-01 00:00:00', '2024-11-30 00:00:00', false),
+      (2, 'Java', '2024-05-01 00:00:00', '2025-03-31 00:00:00', false),
+      (3, 'English', '2024-08-01 00:00:00', '2025-07-31 00:00:00',false),
+      (4, 'Java', '2025-01-01 00:00:00', '2025-03-31 00:00:00', false),
+      (4, 'Music', '2023-04-01 00:00:00', '2026-03-31 00:00:00', false),
+      (5, 'Marketing', '2024-04-01 00:00:00', '2026-03-31 00:00:00',false);
 
+INSERT INTO student_course_status (course_name, course_status_id, status)
+VALUES('Music', 1, '仮申込'),
+      ('Design', 2, '仮申込'),
+      ('Java', 3, '本申込'),
+      ('English', 4, '受講中'),
+      ('Java', 5, '仮申込'),
+      ('Music', 6, '受講終了'),
+      ('Marketing', 7, '仮申込')

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -18,5 +18,14 @@ CREATE TABLE IF NOT EXISTS students_courses
     student_id INT NOT NULL,
     course_name VARCHAR(36) NOT NULL,
     starting_date TIMESTAMP,
-    end_date TIMESTAMP
+    end_date TIMESTAMP,
+    isDeleted boolean
+);
+
+CREATE TABLE IF NOT EXISTS student_course_status
+(
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    course_name VARCHAR(255) NOT NULL,
+    course_status_id INT NOT NULL,
+    status VARCHAR(36) NOT NULL
 );


### PR DESCRIPTION
検索条件の追加と申込状況機能を追加しました

・名前や年齢を指定して受講生を検索する機能を追加
![スクリーンショット 2024-12-10 201853](https://github.com/user-attachments/assets/d91904f2-62a5-4ee6-b711-87ae1c51e9ea)

・受講生情報、受講生コース情報の論理削除機能を追加
![スクリーンショット 2024-12-10 203243](https://github.com/user-attachments/assets/b176edfe-faa6-4a19-a1bc-b0b859f5ed0b)
![スクリーンショット 2024-12-10 203229](https://github.com/user-attachments/assets/cee6ed50-dd7e-49ee-ac45-9a02c9461977)

・コース申込状況の全件検索機能を追加
![スクリーンショット 2024-12-10 202131](https://github.com/user-attachments/assets/00367817-b413-47ad-83a4-d2cb0abfeca2)

・コース申込状況についてコース名を指定して検索する機能を追加
![スクリーンショット 2024-12-10 202144](https://github.com/user-attachments/assets/0360530c-a447-4848-a997-322b39700f3a)

※コース申込状況については受講生の新規登録時に同時に追加されステータスは「仮申込」になるようにしました。

以下はSQLのテーブルになります。
![スクリーンショット 2024-12-10 205612](https://github.com/user-attachments/assets/3f9e3eb7-9176-4dc0-a705-312d17c3a20f)